### PR TITLE
7 게시글과 댓글 제한 변경

### DIFF
--- a/src/main/kotlin/team/kin/forest/domain/comment/persistence/entity/CommentJpaEntity.kt
+++ b/src/main/kotlin/team/kin/forest/domain/comment/persistence/entity/CommentJpaEntity.kt
@@ -10,7 +10,7 @@ import javax.persistence.*
 class CommentJpaEntity (
     override val id: UUID,
 
-    @Column(columnDefinition = "BINARY(500)", nullable = false)
+    @Column(columnDefinition = "VARCHAR(150)", nullable = false)
     val content: String,
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/team/kin/forest/domain/post/persistence/entity/PostJpaEntity.kt
+++ b/src/main/kotlin/team/kin/forest/domain/post/persistence/entity/PostJpaEntity.kt
@@ -11,10 +11,10 @@ import javax.persistence.*
 class PostJpaEntity (
     override val id: UUID,
 
-    @Column(columnDefinition = "VARCHAR(100)", nullable = false)
+    @Column(columnDefinition = "VARCHAR(30)", nullable = false)
     var title: String,
 
-    @Column(columnDefinition = "VARCHAR(1000)", nullable = false)
+    @Column(columnDefinition = "VARCHAR(300)", nullable = false)
     var content: String,
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
- Binary 타입이었던 content 컬럼을 Varchar 타입으로 변경해주었습니다.
- 댓글과 게시글의 크기를 전체적으로 줄였습니다.