### PR TITLE
게시글 삭제 api

### DIFF
--- a/src/main/kotlin/team/kin/forest/domain/comment/adapter/output/persistence/entity/CommentJpaEntity.kt
+++ b/src/main/kotlin/team/kin/forest/domain/comment/adapter/output/persistence/entity/CommentJpaEntity.kt
@@ -1,5 +1,7 @@
 package team.kin.forest.domain.comment.adapter.output.persistence.entity
 
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 import team.kin.forest.domain.post.adapter.output.persistence.entity.PostJpaEntity
 import team.kin.forest.domain.user.adapter.output.persistence.entity.UserJpaEntity
 import team.kin.forest.common.entity.BaseUUIDEntity
@@ -14,10 +16,12 @@ class CommentJpaEntity (
     val content: String,
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "post_id", columnDefinition = "BINARY(16)", nullable = false, updatable = false)
     val post: PostJpaEntity,
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)", nullable = false, updatable = false)
     val user: UserJpaEntity
 ) : BaseUUIDEntity(id)

--- a/src/main/kotlin/team/kin/forest/domain/post/adapter/input/PostWebAdapter.kt
+++ b/src/main/kotlin/team/kin/forest/domain/post/adapter/input/PostWebAdapter.kt
@@ -2,6 +2,7 @@ package team.kin.forest.domain.post.adapter.input
 
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -15,10 +16,7 @@ import team.kin.forest.domain.post.adapter.input.data.request.ModifyPostRequest
 import team.kin.forest.domain.post.adapter.input.data.response.QueryPostDetailsResponse
 import team.kin.forest.domain.post.adapter.input.data.response.QueryPostsResponse
 import team.kin.forest.domain.post.adapter.input.mapper.PostDataMapper
-import team.kin.forest.domain.post.application.port.input.CreatePostUseCase
-import team.kin.forest.domain.post.application.port.input.ModifyPostUseCase
-import team.kin.forest.domain.post.application.port.input.QueryPostDetailsUseCase
-import team.kin.forest.domain.post.application.port.input.QueryPostsUseCase
+import team.kin.forest.domain.post.application.port.input.*
 import java.util.UUID
 import javax.validation.Valid
 
@@ -29,6 +27,7 @@ class PostWebAdapter(
     private val queryPostDetailsUseCase: QueryPostDetailsUseCase,
     private val createPostUseCase: CreatePostUseCase,
     private val modifyPostUseCase: ModifyPostUseCase,
+    private val deletePostUseCase: DeletePostUseCase,
     private val postDataMapper: PostDataMapper
 ) {
     @GetMapping
@@ -58,5 +57,11 @@ class PostWebAdapter(
         @RequestBody @Valid modifyPostRequest: ModifyPostRequest
     ): ResponseEntity<Void> =
         modifyPostUseCase.execute(id, groupId, postDataMapper toDto modifyPostRequest)
+            .let { ResponseEntity.noContent().build() }
+
+    @DeleteMapping("/{post_id}")
+    @MemberOnly
+    fun deletePost(@PathVariable("post_id") id: UUID, @PathVariable("id") groupId: UUID): ResponseEntity<Void> =
+        deletePostUseCase.execute(id, groupId)
             .let { ResponseEntity.noContent().build() }
 }

--- a/src/main/kotlin/team/kin/forest/domain/post/adapter/output/persistence/CommendPostPersistenceAdapter.kt
+++ b/src/main/kotlin/team/kin/forest/domain/post/adapter/output/persistence/CommendPostPersistenceAdapter.kt
@@ -16,4 +16,9 @@ class CommendPostPersistenceAdapter(
         val postEntity = postMapper.toEntity(post)
         return postRepository.save(postEntity).id
     }
+
+    override fun deletePost(post: Post) {
+        val postEntity = postMapper.toEntity(post)
+        return postRepository.delete(postEntity)
+    }
 }

--- a/src/main/kotlin/team/kin/forest/domain/post/adapter/output/persistence/entity/PostJpaEntity.kt
+++ b/src/main/kotlin/team/kin/forest/domain/post/adapter/output/persistence/entity/PostJpaEntity.kt
@@ -1,5 +1,7 @@
 package team.kin.forest.domain.post.adapter.output.persistence.entity
 
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 import team.kin.forest.domain.group.adapter.output.persistence.entity.GroupJpaEntity
 import team.kin.forest.domain.post.adapter.output.persistence.enums.PostTag
 import team.kin.forest.domain.user.adapter.output.persistence.entity.UserJpaEntity
@@ -22,10 +24,12 @@ class PostJpaEntity (
     var postTag: PostTag,
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "group_id", columnDefinition = "BINARY(16)", nullable = false, updatable = false)
     val group: GroupJpaEntity,
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)", nullable = false, updatable = false)
     val user: UserJpaEntity
 ) : BaseUUIDEntity(id)

--- a/src/main/kotlin/team/kin/forest/domain/post/application/port/input/DeletePostUseCase.kt
+++ b/src/main/kotlin/team/kin/forest/domain/post/application/port/input/DeletePostUseCase.kt
@@ -1,0 +1,7 @@
+package team.kin.forest.domain.post.application.port.input
+
+import java.util.*
+
+interface DeletePostUseCase {
+    fun execute(id: UUID, groupId: UUID)
+}

--- a/src/main/kotlin/team/kin/forest/domain/post/application/port/output/CommendPostPort.kt
+++ b/src/main/kotlin/team/kin/forest/domain/post/application/port/output/CommendPostPort.kt
@@ -5,4 +5,5 @@ import java.util.*
 
 interface CommendPostPort {
     fun savePost(post: Post): UUID
+    fun deletePost(post: Post)
 }

--- a/src/main/kotlin/team/kin/forest/domain/post/service/DeletePostService.kt
+++ b/src/main/kotlin/team/kin/forest/domain/post/service/DeletePostService.kt
@@ -5,8 +5,7 @@ import team.kin.forest.domain.group.application.exception.GroupNotFoundException
 import team.kin.forest.domain.group.application.port.output.QueryGroupPort
 import team.kin.forest.domain.post.application.exception.ForbiddenPostException
 import team.kin.forest.domain.post.application.exception.PostNotFoundException
-import team.kin.forest.domain.post.application.port.input.ModifyPostUseCase
-import team.kin.forest.domain.post.application.port.input.dto.ModifyPostDto
+import team.kin.forest.domain.post.application.port.input.DeletePostUseCase
 import team.kin.forest.domain.post.application.port.output.CommendPostPort
 import team.kin.forest.domain.post.application.port.output.QueryPostPort
 import team.kin.forest.domain.user.application.exception.UserNotFoundException
@@ -19,8 +18,8 @@ class DeletePostService(
     private val commendPostPort: CommendPostPort,
     private val queryGroupPort: QueryGroupPort,
     private val queryUserPort: QueryUserPort
-) : ModifyPostUseCase {
-    override fun execute(id: UUID, groupId: UUID, modifyPostDto: ModifyPostDto) {
+) : DeletePostUseCase {
+    override fun execute(id: UUID, groupId: UUID) {
         val group = queryGroupPort.findByIdOrNull(groupId)
             ?: throw GroupNotFoundException()
 

--- a/src/main/kotlin/team/kin/forest/domain/post/service/DeletePostService.kt
+++ b/src/main/kotlin/team/kin/forest/domain/post/service/DeletePostService.kt
@@ -1,0 +1,41 @@
+package team.kin.forest.domain.post.service
+
+import team.kin.forest.common.annotation.ServiceWithTransaction
+import team.kin.forest.domain.group.application.exception.GroupNotFoundException
+import team.kin.forest.domain.group.application.port.output.QueryGroupPort
+import team.kin.forest.domain.post.application.exception.ForbiddenPostException
+import team.kin.forest.domain.post.application.exception.PostNotFoundException
+import team.kin.forest.domain.post.application.port.input.ModifyPostUseCase
+import team.kin.forest.domain.post.application.port.input.dto.ModifyPostDto
+import team.kin.forest.domain.post.application.port.output.CommendPostPort
+import team.kin.forest.domain.post.application.port.output.QueryPostPort
+import team.kin.forest.domain.user.application.exception.UserNotFoundException
+import team.kin.forest.domain.user.application.port.output.QueryUserPort
+import java.util.*
+
+@ServiceWithTransaction
+class DeletePostService(
+    private val queryPostPort: QueryPostPort,
+    private val commendPostPort: CommendPostPort,
+    private val queryGroupPort: QueryGroupPort,
+    private val queryUserPort: QueryUserPort
+) : ModifyPostUseCase {
+    override fun execute(id: UUID, groupId: UUID, modifyPostDto: ModifyPostDto) {
+        val group = queryGroupPort.findByIdOrNull(groupId)
+            ?: throw GroupNotFoundException()
+
+        val post = queryPostPort.findByIdOrNull(id)
+            ?: throw PostNotFoundException()
+
+        val user = queryUserPort.findCurrentUser()
+            ?: throw UserNotFoundException()
+
+        if(post.user.id != user.id) {
+            if (group.manager.id != user.id) {
+                throw ForbiddenPostException()
+            }
+        }
+
+        commendPostPort.deletePost(post)
+    }
+}

--- a/src/main/kotlin/team/kin/forest/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/kin/forest/global/security/config/SecurityConfig.kt
@@ -44,6 +44,7 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.POST, "/group/{id}/post").authenticated()
             .mvcMatchers(HttpMethod.GET, "/group/{id}/post/{post_id}").authenticated()
             .mvcMatchers(HttpMethod.PATCH, "/group/{id}/post/{post_id}").authenticated()
+            .mvcMatchers(HttpMethod.DELETE, "/group/{id}/post/{post_id}").authenticated()
 
             .mvcMatchers(HttpMethod.POST, "/group/{id}/post/{post_id}/comment").authenticated()
             .mvcMatchers(HttpMethod.PATCH, "/group/{id}/post/{post_id}/comment/{comment_id}").authenticated()


### PR DESCRIPTION
게시글 삭제 api를 작성했습니다.

cascade delete가 다대일에서는 작동하지 않아서,, FK 문제를 해결하기 위해 엔티티에 @OnDelete(action = OnDeleteAction.CASCADE)를 붙여주었습니다!

대신 이게 적용되려면 다시 테이블을 생성해야 해서 아페 전시가 끝난 뒤 초기화하도록 할게요!! 